### PR TITLE
Remove newtype warning in Puppet 4.8

### DIFF
--- a/lib/puppet/type/zypprepo.rb
+++ b/lib/puppet/type/zypprepo.rb
@@ -50,7 +50,7 @@ module Puppet
   # Doc string for properties that can be made 'absent'
   ABSENT_DOC="Set this to `absent` to remove it from the file completely."
 
-  newtype(:zypprepo) do
+  Puppet::Type.newtype(:zypprepo) do
     @doc = "The client-side description of a zypper repository. Repository
       configurations are found by parsing `/etc/zypp/zypper.conf` and
       the files indicated by the `reposdir` option in that file


### PR DESCRIPTION
Just using 'newtype' creates the following warning in Puppet 4.8 and above:
Warning: Creating zypprepo via Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.