### PR TITLE
NONE is a valid value for Zypp repositories

### DIFF
--- a/lib/puppet/type/zypprepo.rb
+++ b/lib/puppet/type/zypprepo.rb
@@ -274,9 +274,9 @@ module Puppet
 
     newproperty(:type, parent: Puppet::IniProperty) do
       desc "The type of software repository. Values can match
-         `yast2` or `rpm-md` or `plaindir` or `yum`. #{ABSENT_DOC}"
+         `yast2` or `rpm-md` or `plaindir` or `yum` or `NONE`. #{ABSENT_DOC}"
       newvalue(:absent) { self.should = :absent }
-      newvalue(%r{yast2|rpm-md|plaindir|yum}) {}
+      newvalue(%r{yast2|rpm-md|plaindir|yum|NONE}) {}
     end
   end
 end


### PR DESCRIPTION
This was tested in SLES and OpenSuSE 42.2. This is required for an SAP HANA repository for SLES. NONE is considered to be a valid value per SLES SAP Instructions. Also `zipper ar -f <<URL>> <<NAME>> sets this for the SAP repository automatically.

Signed-off-by: Anthony Leto <anthonyleto@mac.com>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->