### PR TITLE
migrate zypprepo from type only to type and provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@
 
 ## Usage
 
+**Version 3.1.0 introduced a rewrite of the zypprepo type and added a full functional provider based on `puppetlabs-yumrepo_core`. The type is now ensurable. To keep previous behavior, it defaults to present, which makes the ensure parameter optional**
+
 ```puppet
 zypprepo { 'openSUSE_12.1':
+  ensure        => present,
   baseurl       => 'http://download.opensuse.org/distribution/12.1/repo/oss/suse/',
   enabled       => 1,
   autorefresh   => 1,

--- a/lib/puppet/provider/zypprepo/inifile.rb
+++ b/lib/puppet/provider/zypprepo/inifile.rb
@@ -1,0 +1,311 @@
+# Description of zypper repositories
+require 'puppet/util/inifile'
+
+
+Puppet::Type.type(:zypprepo).provide(:inifile) do
+  desc <<-EOD
+    Manage zypper repo configurations by parsing zypper INI configuration files.
+
+    ### Fetching instances
+    When fetching repo instances, directory entries in '/etc/zypp/repos.d',
+    and the directory optionally specified by the reposdir key in '/etc/zypp/zypper.conf'
+    will be checked. If a given directory does not exist it will be ignored.
+    In addition, all sections in '/etc/zypp/zypper.conf' aside from
+    'main' will be created as sections.
+
+    ### Storing instances
+    When creating a new repository, a new section will be added in the first
+    zypper repo directory that exists. The custom directory specified by the
+    '/etc/zypp/zypper.conf' reposdir property is checked first, followed by
+    '/etc/zypp/repos.d'.
+  EOD
+
+  PROPERTIES = Puppet::Type.type(:zypprepo).validproperties
+
+  # Retrieve all providers based on existing zypper repositories
+  #
+  # @api public
+  # @return [Array<Puppet::Provider>] providers generated from existing zypper
+  #   repository definitions.
+  def self.instances
+    instances = []
+
+    virtual_inifile.each_section do |section|
+      # Ignore the 'main' section in zypper.conf since it's not a repository.
+      next if section.name == 'main'
+
+      attributes_hash = { name: section.name, ensure: :present, provider: :zypprepo }
+
+      section.entries.each do |key, value|
+        key = key.to_sym
+        if valid_property?(key)
+          attributes_hash[key] = value
+        elsif key == :name
+          attributes_hash[:descr] = value
+        end
+      end
+      instances << new(attributes_hash)
+    end
+
+    instances
+  end
+
+  # Match catalog type instances to provider instances.
+  #
+  # @api public
+  # @param resources [Array<Puppet::Type::Zypprepo>] Resources to prefetch.
+  # @return [void]
+  def self.prefetch(resources)
+    repos = instances
+    resources.each_key do |name|
+      provider = repos.find { |repo| repo.name == name }
+      if provider
+        resources[name].provider = provider
+      end
+    end
+  end
+
+
+  #
+  # @api private
+  # @param conf [String] Configuration file to look for directories in.
+  # @param dirs [Array<String>] Default locations for zypper repos.
+  # @return [Array<String>] All present directories that may contain zypper repo configs.
+  def self.reposdir(conf = '/etc/zypp/zypper.conf', dirs = ['/etc/zypp/repos.d'])
+    reposdir = find_conf_value('reposdir', conf)
+    # Use directories in reposdir if they are set instead of default
+    if reposdir
+      # Follow the code from the yumrepo provider
+      reposdir.tr!("\n", ' ')
+      reposdir.tr!(',', ' ')
+      dirs = reposdir.split
+    end
+    dirs.select! { |dir| Puppet::FileSystem.exist?(dir) }
+    if dirs.empty?
+      Puppet.debug('No zypper directories were found on the local filesystem')
+    end
+
+    dirs
+  end
+
+  # Used for testing only
+  # @api private
+  def self.clear
+    @virtual = nil
+  end
+
+  # Helper method to look up specific values in ini style files.
+  #
+  # @api private
+  # @param value [String] Value to look for in the configuration file.
+  # @param conf [String] Configuration file to check for value.
+  # @return [String] The value of a looked up key from the configuration file.
+  def self.find_conf_value(value, conf = '/etc/zypp/zypper.conf')
+    return unless Puppet::FileSystem.exist?(conf)
+
+    file = Puppet::Util::IniConfig::PhysicalFile.new(conf)
+    file.read
+    main = file.get_section('main')
+    main ? main[value] : nil
+  end
+
+  # Enumerate all files that may contain zypper repository configs.
+  #
+  # @api private
+  # @return [Array<String>
+  def self.repofiles
+    files = []
+    reposdir.each do |dir|
+      Dir.glob("#{dir}/*.repo").each do |file|
+        files << file
+      end
+    end
+
+    files
+  end
+
+  # Build a virtual inifile by reading in numerous .repo files into a single
+  # virtual file to ease manipulation.
+  # @api private
+  # @return [Puppet::Util::IniConfig::File] The virtual inifile representing
+  #   multiple real files.
+  def self.virtual_inifile
+    unless @virtual
+      @virtual = Puppet::Util::IniConfig::File.new
+      repofiles.each do |file|
+        @virtual.read(file) if Puppet::FileSystem.file?(file)
+      end
+    end
+    @virtual
+  end
+
+  # Is the given key a valid type property?
+  #
+  # @api private
+  # @param key [String] The property to look up.
+  # @return [Boolean] Returns true if the property is defined in the type.
+  def self.valid_property?(key)
+    PROPERTIES.include?(key)
+  end
+
+  # Return an existing INI section or create a new section in the default location
+  #
+  # The default location is determined based on what zypper repo directories
+  # and files are present. If /etc/zypp/zypper.conf has a value for 'reposdir' then that
+  # is preferred. If no such INI property is found then the first default zypper
+  # repo directory that is present is used.
+  #
+  # @param name [String] Section name to lookup in the virtual inifile.
+  # @return [Puppet::Util::IniConfig] The IniConfig section
+  def self.section(name)
+    result = virtual_inifile[name]
+    # Create a new section if not found.
+    unless result
+      path = repo_path(name)
+      result = virtual_inifile.add_section(name, path)
+    end
+    result
+  end
+
+  # Save all zypper repository files and force the mode to 0644
+  # @api private
+  # @return [void]
+  def self.store(resource)
+    inifile = virtual_inifile
+    inifile.store
+
+    target_mode = 0o644
+    inifile.each_file do |file|
+      next unless Puppet::FileSystem.exist?(file)
+      current_mode = Puppet::FileSystem.stat(file).mode & 0o777
+      next if current_mode == target_mode
+      resource.info _('changing mode of %{file} from %{current_mode} to %{target_mode}') %
+                    { file: file, current_mode: '%03o' % current_mode, target_mode: '%03o' % target_mode }
+      Puppet::FileSystem.chmod(target_mode, file)
+    end
+  end
+
+  def self.repo_path(name)
+    dirs = reposdir
+    path = if dirs.empty?
+             # If no repo directories are present, default to using /etc/zypp/repos.d.
+             '/etc/zypp/repos.d'
+           else
+             # The ordering of reposdir is [defaults, custom], and we want to use
+             # the custom directory if present.
+             File.join(dirs.last, "#{name}.repo")
+           end
+    path
+  end
+
+  # Create a new section for the given repository and set all the specified
+  # properties in the section.
+  #
+  # @api public
+  # @return [void]
+  def create
+    @property_hash[:ensure] = :present
+
+    # Check to see if the file that would be created in the
+    # default location for the zypprepo already exists on disk.
+    # If it does, read it in to the virtual inifile
+    path = self.class.repo_path(name)
+    self.class.virtual_inifile.read(path) if Puppet::FileSystem.file?(path)
+
+    # We fetch a list of properties from the type, then iterate
+    # over them, avoiding ensure.  We're relying on .should to
+    # check if the property has been set and should be modified,
+    # and if so we set it in the virtual inifile.
+    PROPERTIES.each do |property|
+      next if property == :ensure
+
+      value = @resource.should(property)
+      send("#{property}=", value) if value
+    end
+  end
+
+  # Does the given repository already exist?
+  #
+  # @api public
+  # @return [Boolean]
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  # Mark the given repository section for destruction.
+  #
+  # The actual removal of the section will be handled by {#flush} after the
+  # resource has been fully evaluated.
+  #
+  # @api public
+  # @return [void]
+  def destroy
+    # Flag file for deletion on flush.
+    current_section.destroy = true
+
+    @property_hash.clear
+  end
+
+  # Finalize the application of the given resource.
+  #
+  # @api public
+  # @return [void]
+  def flush
+    self.class.store(self)
+  end
+
+  # Generate setters and getters for our INI properties.
+  PROPERTIES.each do |property|
+    # The ensure property uses #create, #exists, and #destroy we can't generate
+    # meaningful setters and getters for this
+    next if property == :ensure
+
+    define_method(property) do
+      get_property(property)
+    end
+
+    define_method("#{property}=") do |value|
+      set_property(property, value)
+    end
+  end
+
+  # Map the zypprepo 'descr' type property to the 'name' INI property.
+  def descr
+    unless @property_hash.key?(:descr)
+      @property_hash[:descr] = current_section['name']
+    end
+    value = @property_hash[:descr]
+    value.nil? ? :absent : value
+  end
+
+  def descr=(value)
+    value = ((value == :absent) ? nil : value)
+    current_section['name'] = value
+    @property_hash[:descr] = value
+  end
+
+  private
+
+  def get_property(property)
+    unless @property_hash.key?(property)
+      @property_hash[property] = current_section[property.to_s]
+    end
+    value = @property_hash[property]
+    value.nil? ? :absent : value
+  end
+
+  def set_property(property, value)
+    value = ((value == :absent) ? nil : value)
+    current_section[property.to_s] = value
+    @property_hash[property] = value
+  end
+
+  def section(name)
+    self.class.section(name)
+  end
+
+  def current_section
+    self.class.section(name)
+  end
+
+end

--- a/lib/puppet/type/zypprepo.rb
+++ b/lib/puppet/type/zypprepo.rb
@@ -1,298 +1,103 @@
 # Description of zypper repositories
 
-require 'puppet/util/inifile'
+Puppet::Type.newtype(:zypprepo) do
+  @doc = "The client-side description of a zypper repository. Repository
+    configurations are found by parsing `/etc/zypp/zypper.conf` and
+    the files indicated by the `reposdir` option in that file
+    (see `zypper(8)` for details).
 
-module Puppet
-  # A property for one entry in a .ini-style file
-  class IniProperty < Puppet::Property
-    def insync?(is)
-      # A should property of :absent is the same as nil
-      return true if is.nil? && should == :absent
-      super(is)
-    end
+    Most parameters are identical to the ones documented
+    in the `zypper(8)` man page.
 
-    def sync
-      if safe_insync?(retrieve)
-        result = nil
-      else
-        result = set(should)
-        resource.section[inikey] = if should == :absent
-                                     nil
-                                   else
-                                     should
-                                   end
-      end
-      result
-    end
+    Continuation lines that zypper supports (for the `baseurl`, for example)
+    are not supported. This type does not attempt to read or verify the
+    exinstence of files listed in the `include` attribute."
 
-    def retrieve
-      resource.section[inikey]
-    end
-
-    def inikey
-      name.to_s
-    end
-
-    # Set the key associated with this property to KEY, instead
-    # of using the property's NAME
-    def self.inikey(key)
-      # Override the inikey instance method
-      # Is there a way to do this without resorting to strings ?
-      # Using a block fails because the block can't access
-      # the variable 'key' in the outer scope
-      class_eval("def inikey ; \"#{key}\" ; end")
-    end
-  end
-
+  ensurable
   # Doc string for properties that can be made 'absent'
   ABSENT_DOC = 'Set this to `absent` to remove it from the file completely.'.freeze
 
-  Puppet::Type.newtype(:zypprepo) do
-    @doc = "The client-side description of a zypper repository. Repository
-      configurations are found by parsing `/etc/zypp/zypper.conf` and
-      the files indicated by the `reposdir` option in that file
-      (see `zypper(8)` for details).
+  newparam(:name) do
+    desc "The name of the repository.  This corresponds to the
+      `repositoryid` parameter in `zypper(8)`."
+    isnamevar
+  end
 
-      Most parameters are identical to the ones documented
-      in the `zypper(8)` man page.
+  newproperty(:descr) do
+    desc "A human-readable description of the repository.
+      This corresponds to the name parameter in `zypper(8)`.
+      #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{.*}) {}
+  end
 
-      Continuation lines that zypper supports (for the `baseurl`, for example)
-      are not supported. This type does not attempt to read or verify the
-      exinstence of files listed in the `include` attribute."
+  newproperty(:mirrorlist) do
+    desc "The URL that holds the list of mirrors for this repository.
+      #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{.*}) {}
+  end
 
-    class << self
-      attr_accessor :filetype
-      # The writer is only used for testing, there should be no need
-      # to change zypperconf or inifile in any other context
-      attr_accessor :zypperconf
-      attr_writer :inifile
-    end
+  newproperty(:baseurl) do
+    desc "The URL for this repository. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    # Should really check that it's a valid URL
+    newvalue(%r{.*}) {}
+  end
 
-    self.filetype = Puppet::Util::FileType.filetype(:flat)
+  newproperty(:path) do
+    desc "The path relative to the baseurl. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{.*}) {}
+  end
 
-    @inifile = nil
+  newproperty(:enabled) do
+    desc "Whether this repository is enabled, as represented by a
+      `0` or `1`. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{(0|1)}) {}
+  end
 
-    @zypperconf = '/etc/zypp/zypper.conf'
+  newproperty(:gpgcheck) do
+    desc "Whether to check the GPG signature on packages installed
+      from this repository, as represented by a `0` or `1`.
+      #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{(0|1)}) {}
+  end
 
-    # Where to put files for brand new sections
-    @defaultrepodir = nil
+  newproperty(:gpgkey) do
+    desc "The URL for the GPG key with which packages from this
+      repository are signed. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    # Should really check that it's a valid URL
+    newvalue(%r{.*}) {}
+  end
 
-    def self.instances
-      l = []
-      check = validproperties
-      clear
-      inifile.each_section do |s|
-        next if s.name == 'main'
-        obj = new(name: s.name, audit: check)
-        current_values = obj.retrieve
-        obj.eachproperty do |property|
-          if current_values[property].nil?
-            obj.delete(property.name)
-          else
-            property.should = current_values[property]
-          end
-        end
-        obj.delete(:audit)
-        l << obj
-      end
-      l
-    end
+  newproperty(:priority) do
+    desc "Priority of this repository from 1-99. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{[1-9][0-9]?}) {}
+  end
 
-    # Return the Puppet::Util::IniConfig::File for the whole zypper config
-    def self.inifile
-      if @inifile.nil?
-        @inifile = read
-        main = @inifile['main']
-        raise Puppet::Error, "File #{zypperconf} does not contain a main section" if main.nil?
-        reposdir = main['reposdir']
-        reposdir ||= '/etc/zypp/repos.d'
-        reposdir.gsub!(%r{[\n,]}, ' ')
-        reposdir.split.each do |dir|
-          Dir.glob("#{dir}/*.repo").each do |file|
-            @inifile.read(file) if File.file?(file)
-          end
-        end
-        reposdir.split.each do |dir|
-          if File.directory?(dir) && File.writable?(dir)
-            @defaultrepodir = dir
-            break
-          end
-        end
-      end
-      @inifile
-    end
+  newproperty(:autorefresh) do
+    desc "Enable autorefresh of the repository, as represented by a
+      `0` or `1`. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{(0|1)}) {}
+  end
 
-    # Parse the zypper config files. Only exposed for the tests
-    # Non-test code should use self.inifile to get at the
-    # underlying file
-    def self.read
-      result = Puppet::Util::IniConfig::File.new
-      result.read(zypperconf)
-      main = result['main']
-      raise Puppet::Error, "File #{zypperconf} does not contain a main section" if main.nil?
-      reposdir = main['reposdir']
-      reposdir ||= '/etc/zypp/repos.d'
-      reposdir.gsub!(%r{[\n,]}, ' ')
-      reposdir.split.each do |dir|
-        Dir.glob("#{dir}/*.repo").each do |file|
-          result.read(file) if File.file?(file)
-        end
-      end
-      if @defaultrepodir.nil?
-        reposdir.split.each do |dir|
-          if File.directory?(dir) && File.writable?(dir)
-            @defaultrepodir = dir
-            break
-          end
-        end
-      end
-      result
-    end
+  newproperty(:keeppackages) do
+    desc "Enable RPM files caching, as represented by a
+      `0` or `1`. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{(0|1)}) {}
+  end
 
-    # Return the Puppet::Util::IniConfig::Section with name NAME
-    # from the zypper config
-    def self.section(name)
-      result = inifile[name]
-      if result.nil?
-        # Brand new section
-        path = zypperconf
-        path = File.join(@defaultrepodir, "#{name}.repo") unless @defaultrepodir.nil?
-        Puppet.info "create new repo #{name} in file #{path}"
-        result = inifile.add_section(name, path)
-      end
-      result
-    end
-
-    # Store all modifications back to disk
-    def self.store
-      inifile.store
-      return if Puppet[:noop]
-      target_mode = 0o644 # FIXME: should be configurable
-      inifile.each_file do |file|
-        current_mode = File.stat(file).mode & 0o777
-        unless current_mode == target_mode
-          Puppet.info "changing mode of #{file} from %03o to %03o" % [current_mode, target_mode] # rubocop:disable Style/FormatString
-          File.chmod(target_mode, file)
-        end
-      end
-    end
-
-    # This is only used during testing.
-    def self.clear
-      @inifile = nil
-      @zypperconf = '/etc/zypp/zypper.conf'
-      @defaultrepodir = nil
-    end
-
-    # Return the Puppet::Util::IniConfig::Section for this zypprepo resource
-    def section
-      self.class.section(self[:name])
-    end
-
-    # Store modifications to this zypprepo resource back to disk
-    def flush
-      self.class.store
-    end
-
-    newparam(:name) do
-      desc "The name of the repository.  This corresponds to the
-        `repositoryid` parameter in `zypper(8)`."
-      isnamevar
-    end
-
-    newproperty(:descr, parent: Puppet::IniProperty) do
-      desc "A human-readable description of the repository.
-        This corresponds to the name parameter in `zypper(8)`.
-        #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{.*}) {}
-      inikey 'name'
-    end
-
-    newproperty(:mirrorlist, parent: Puppet::IniProperty) do
-      desc "The URL that holds the list of mirrors for this repository.
-        #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{.*}) {}
-    end
-
-    newproperty(:baseurl, parent: Puppet::IniProperty) do
-      desc "The URL for this repository. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      # Should really check that it's a valid URL
-      newvalue(%r{.*}) {}
-    end
-
-    newproperty(:path, parent: Puppet::IniProperty) do
-      desc "The path relative to the baseurl. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{.*}) {}
-    end
-
-    newproperty(:enabled, parent: Puppet::IniProperty) do
-      desc "Whether this repository is enabled, as represented by a
-        `0` or `1`. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:gpgcheck, parent: Puppet::IniProperty) do
-      desc "Whether to check the GPG signatures
-        from this repository, as represented by a `0` or `1`.
-        #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:repo_gpgcheck, parent: Puppet::IniProperty) do
-      desc "Whether to check the GPG signature on the repository
-         metadata, as represented by a `0` or `1`.
-        #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:pkg_gpgcheck, parent: Puppet::IniProperty) do
-      desc "Whether to check the GPG signature on packages installed
-        from this repository, as represented by a `0` or `1`.
-        #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:gpgkey, parent: Puppet::IniProperty) do
-      desc "The URL for the GPG key with which packages from this
-        repository are signed. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      # Should really check that it's a valid URL
-      newvalue(%r{.*}) {}
-    end
-
-    newproperty(:priority, parent: Puppet::IniProperty) do
-      desc "Priority of this repository from 1-99. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{[1-9][0-9]?}) {}
-    end
-
-    newproperty(:autorefresh, parent: Puppet::IniProperty) do
-      desc "Enable autorefresh of the repository, as represented by a
-        `0` or `1`. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:keeppackages, parent: Puppet::IniProperty) do
-      desc "Enable RPM files caching, as represented by a
-        `0` or `1`. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{(0|1)}) {}
-    end
-
-    newproperty(:type, parent: Puppet::IniProperty) do
-      desc "The type of software repository. Values can match
-         `yast2` or `rpm-md` or `plaindir` or `yum` or `NONE`. #{ABSENT_DOC}"
-      newvalue(:absent) { self.should = :absent }
-      newvalue(%r{yast2|rpm-md|plaindir|yum|NONE}) {}
-    end
+  newproperty(:type) do
+    desc "The type of software repository. Values can match
+       `yast2` or `rpm-md` or `plaindir` or `yum` or `NONE`. #{ABSENT_DOC}"
+    newvalue(:absent) { self.should = :absent }
+    newvalue(%r{yast2|rpm-md|plaindir|yum|NONE}) {}
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

adopt the yumrepo type/provider to zypprepo.

Open issue: repo files will be emptied, but not removed when using
ensure => absent

#### This Pull Request (PR) fixes the following issues
Fixes #5
Fixes #9
