### PR TITLE
Fix the value declaration of type

### DIFF
--- a/lib/puppet/type/zypprepo.rb
+++ b/lib/puppet/type/zypprepo.rb
@@ -151,7 +151,6 @@ Puppet::Type.newtype(:zypprepo) do
   newproperty(:type) do
     desc "The type of software repository. Values can match
        `yast2` or `rpm-md` or `plaindir` or `yum` or `NONE`. #{ABSENT_DOC}"
-    newvalue(:absent) { self.should = :absent }
-    newvalue(%r{yast2|rpm-md|plaindir|yum|NONE}) {}
+    newvalues(%r{yast2|rpm-md|plaindir|yum|NONE}, :absent)
   end
 end


### PR DESCRIPTION
The value declaration should be done in the same way as in the other
properties. The old way doesn't work.

Fixes #59